### PR TITLE
 linux: Fix build for new OE versions

### DIFF
--- a/recipes-bsp/linux/linux-hd_3.17.3.bb
+++ b/recipes-bsp/linux/linux-hd_3.17.3.bb
@@ -32,9 +32,9 @@ SRC_URI += "http://downloads.mutant-digital.net/linux-${PV}.tar.gz \
 	file://tda18271-advertise-supported-delsys.patch \
 	"
 
-S = "${WORKDIR}/linux-${PV}"
-
 inherit kernel machine_kernel_pr
+
+S = "${WORKDIR}/linux-${PV}"
 
 export OS = "Linux"
 KERNEL_OBJECT_SUFFIX = "ko"
@@ -43,11 +43,6 @@ KERNEL_IMAGETYPE = "vmlinux"
 KERNEL_IMAGEDEST = "/tmp"
 
 FILES_kernel-image = "${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}*"
-
-do_configure_prepend() {
-	oe_machinstall -m 0644 ${WORKDIR}/defconfig ${S}/.config
-	oe_runmake oldconfig
-}
 
 kernel_do_install_append() {
 	${STRIP} ${D}${KERNEL_IMAGEDEST}/${KERNEL_IMAGETYPE}-${KERNEL_VERSION}


### PR DESCRIPTION
The kernel build recipes have undergone massive changes in newer
OpenEmbedded versions. This results in build failures like this:

| make: **\* No rule to make target `oldconfig'.  Stop.

To resolve the issue, move the assignment of "S" to after the
"inherit kernel" statement, and remove the manual defconfig
handling, OE already takes care of that.
